### PR TITLE
Add flag --generate-null-safe to generate null safe code.

### DIFF
--- a/generator/bin/generate.dart
+++ b/generator/bin/generate.dart
@@ -19,7 +19,8 @@ ArgParser runConfigCommandArgParser() => ArgParser()
   ..addCommand('generate')
   ..addOption('config-file',
       help: 'Configuration file describing package generation.',
-      defaultsTo: 'config.yaml');
+      defaultsTo: 'config.yaml')
+  ..addFlag('generate-null-safe', help: 'Whether to generate null safe code.');
 
 ArgParser globalArgParser() => ArgParser()
   ..addCommand('download', downloadCommandArgParser())
@@ -83,12 +84,13 @@ void main(List<String> arguments) {
       }
 
       final configFile = commandOptions['config-file'];
+      final generateNullSafe = commandOptions['generate-null-safe'] as bool;
       switch (commandOptions.command.name) {
         case 'download':
           downloadFromConfiguration(configFile).then((_) => print('Done!'));
           break;
         case 'generate':
-          generateFromConfiguration(configFile);
+          generateFromConfiguration(configFile, generateNullSafe);
           print('Done');
           break;
       }

--- a/generator/lib/googleapis_generator.dart
+++ b/generator/lib/googleapis_generator.dart
@@ -120,13 +120,13 @@ Future downloadFromConfiguration(String configFile) async {
   }
 }
 
-void generateFromConfiguration(String configFile) {
+void generateFromConfiguration(String configFile, bool generateNullSafe) {
   final configuration = DiscoveryPackagesConfiguration(configFile);
 
   // Generate the packages.
   final configFileUri = Uri.file(configFile);
   return configuration.generate(configFileUri.resolve('discovery').path,
-      configFileUri.resolve('generated').path);
+      configFileUri.resolve('generated').path, generateNullSafe);
 }
 
 DiscoveryApi _discoveryClient(http.Client client) => DiscoveryApi(client);

--- a/generator/lib/src/package_configuration.dart
+++ b/generator/lib/src/package_configuration.dart
@@ -123,7 +123,8 @@ class DiscoveryPackagesConfiguration {
   ///
   /// [generatedApisDir] is the directory where the packages are generated.
   /// Each package is generated in a sub-directory.
-  void generate(String discoveryDocsDir, String generatedApisDir) {
+  void generate(
+      String discoveryDocsDir, String generatedApisDir, bool generateNullSafe) {
     // Delete all downloaded discovery documents.
     final dir = Directory(discoveryDocsDir);
     if (!dir.existsSync()) {
@@ -142,8 +143,9 @@ class DiscoveryPackagesConfiguration {
 
     // Generate packages.
     packages.forEach((name, package) {
-      final results = generateAllLibraries('$discoveryDocsDir/$name',
-          '$generatedApisDir/$name', package.pubspec);
+      final results = generateAllLibraries(
+          '$discoveryDocsDir/$name', '$generatedApisDir/$name', package.pubspec,
+          generateNullSafe: generateNullSafe);
       for (final result in results) {
         if (!result.success) {
           print(result.toString());


### PR DESCRIPTION
Depends on https://github.com/dart-lang/discoveryapis_generator/pull/230 ... that project is pulled from HEAD, so as soon as that is merged this should work.